### PR TITLE
Pull sensu-server fqdn from the pillar data instead of grains

### DIFF
--- a/SPECFILE
+++ b/SPECFILE
@@ -19,17 +19,20 @@ components:
     description: Sensu plugins
     sls_path: monitor.sensu.plugins
 
-  - title: Sensu Mutators
-    description: Sensu mutators
-    sls_path: monitor.sensu.mutators
-
-  - title: Sensu Handlers
-    description: Sensu handlers
-    sls_path: monitor.sensu.handlers
-
-  - title: Sensu Extensions
-    description: Sensu extensions
-    sls_path: monitor.sensu.extensions
+# I don't think there's ever a reason to run these states explicitly, since they're always included
+#    in monitor.sensu.server, and are not meant to be run on clients
+#
+#  - title: Sensu Mutators
+#    description: Sensu mutators
+#    sls_path: monitor.sensu.mutators
+#
+#  - title: Sensu Handlers
+#    description: Sensu handlers
+#    sls_path: monitor.sensu.handlers
+#
+#  - title: Sensu Extensions
+#    description: Sensu extensions
+#    sls_path: monitor.sensu.extensions
 
   - title: Graphite
     description: Graphite

--- a/SPECFILE
+++ b/SPECFILE
@@ -51,6 +51,8 @@ pillar_defaults:
       client:
         subscriptions:
           - all
+      server:
+        fqdn: localhost
       api:
         username: admin 
         password: CHANGEME
@@ -81,3 +83,4 @@ pillar_defaults:
       url: CHANGEME
       user: CHANGEME
       password: CHANGEME
+      admin: false

--- a/SPECFILE
+++ b/SPECFILE
@@ -19,21 +19,6 @@ components:
     description: Sensu plugins
     sls_path: monitor.sensu.plugins
 
-# I don't think there's ever a reason to run these states explicitly, since they're always included
-#    in monitor.sensu.server, and are not meant to be run on clients
-#
-#  - title: Sensu Mutators
-#    description: Sensu mutators
-#    sls_path: monitor.sensu.mutators
-#
-#  - title: Sensu Handlers
-#    description: Sensu handlers
-#    sls_path: monitor.sensu.handlers
-#
-#  - title: Sensu Extensions
-#    description: Sensu extensions
-#    sls_path: monitor.sensu.extensions
-
   - title: Graphite
     description: Graphite
     sls_path: monitor.graphite

--- a/monitor/etc/sensu/conf.d/client.json
+++ b/monitor/etc/sensu/conf.d/client.json
@@ -1,4 +1,4 @@
-{%- set hostname = salt['mine.get']('G@fqdn:' ~ grains.fqdn, 'grains.items', 'compound').values()[0]['fqdn'] -%}
+{%- set hostname = grains.fqdn -%}
 {%- set custom_subscriptions = salt['pillar.get']('custom_sensu_subscriptions', []) -%}
 {%- set subscriptions = salt['pillar.get']('monitor:sensu:client:subscriptions') + [hostname] + custom_subscriptions -%}
 {

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -46,6 +46,6 @@
     "stackdio_url": "{{ pillar.monitor.stackdio.url }}",
     "stackdio_user": "{{ pillar.monitor.stackdio.user }}",
     "stackdio_password": "{{ pillar.monitor.stackdio.password }}",
-    "stackdio_admin": {{ pillar.monitor.stackdio.admin }}
+    "stackdio_admin": {{ pillar.monitor.stackdio.admin | json }}
   }
 }

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -46,6 +46,6 @@
     "stackdio_url": "{{ pillar.monitor.stackdio.url }}",
     "stackdio_user": "{{ pillar.monitor.stackdio.user }}",
     "stackdio_password": "{{ pillar.monitor.stackdio.password }}",
-    "stackdio_admin": "{{ pillar.monitor.stackdio.admin }}"
+    "stackdio_admin": {{ pillar.monitor.stackdio.admin }}
   }
 }

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -45,6 +45,7 @@
   "delete-hosts": {
     "stackdio_url": "{{ pillar.monitor.stackdio.url }}",
     "stackdio_user": "{{ pillar.monitor.stackdio.user }}",
-    "stackdio_password": "{{ pillar.monitor.stackdio.password }}"
+    "stackdio_password": "{{ pillar.monitor.stackdio.password }}",
+    "stackdio_admin": "{{ pillar.monitor.stackdio.admin }}"
   }
 }

--- a/monitor/etc/sensu/conf.d/rabbitmq.json
+++ b/monitor/etc/sensu/conf.d/rabbitmq.json
@@ -1,11 +1,10 @@
-{%- set hostname = salt['mine.get']('G@roles:monitor.sensu.server', 'grains.items', 'compound').values()[0]['fqdn'] -%}
 {
   "rabbitmq": {
     "ssl": {
       "cert_chain_file": "/etc/sensu/ssl/cert.pem",
       "private_key_file": "/etc/sensu/ssl/key.pem"
     },
-    "host": "{{ hostname }}",
+    "host": "{{ pillar.monitor.sensu.server.fqdn }}",
     "port": 5671,
     "vhost": "{{ pillar.monitor.sensu.rabbitmq.vhost }}",
     "user": "{{ pillar.monitor.sensu.rabbitmq.username }}",

--- a/monitor/etc/sensu/handlers/delete-hosts.rb
+++ b/monitor/etc/sensu/handlers/delete-hosts.rb
@@ -18,7 +18,8 @@ class Deleter < Sensu::Handler
     params = {
       :stackdio_url      => settings['delete-hosts']['stackdio_url'],
       :stackdio_user     => settings['delete-hosts']['stackdio_user'],
-      :stackdio_password => settings['delete-hosts']['stackdio_password']
+      :stackdio_password => settings['delete-hosts']['stackdio_password'],
+      :stackdio_admin    => settings['delete-hosts']['stackdio_admin']
     }
 
     host_fqdn = @event['client']['address']
@@ -29,7 +30,11 @@ class Deleter < Sensu::Handler
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = (uri.scheme == "https")
 
-        req = Net::HTTP::Get.new('/api/admin/stacks/')
+        if params[:stackdio_admin]
+            req = Net::HTTP::Get.new('/api/admin/stacks/')
+        else
+            req = Net::HTTP::Get.new('/api/stacks/')
+        end
         req['Accept'] = 'application/json'
         req.basic_auth(params[:stackdio_user], params[:stackdio_password])
 

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -13,6 +13,8 @@ sensu-client-pkg:
   pkg:
     - installed
     - name: sensu
+    - require:
+      - pkgrepo: sensu-repo
 
 /etc/sensu/ssl/cert.pem:
   file:
@@ -73,4 +75,6 @@ restart_sensu:
   cmd:
     - run
     - name: /usr/share/sensu/restart_sensu.sh
+    - require:
+      - service: sensu-client
 {% endif %}

--- a/monitor/sensu/extensions/init.sls
+++ b/monitor/sensu/extensions/init.sls
@@ -16,4 +16,8 @@
     - recurse: true
     - source: salt://monitor/etc/sensu/extensions
     - template: jinja
+    - require:
+      - pkg: sensu-server-pkg
+    - require_in:
+      - service: sensu-server
 

--- a/monitor/sensu/handlers/init.sls
+++ b/monitor/sensu/handlers/init.sls
@@ -16,6 +16,10 @@
     - recurse: true
     - source: salt://monitor/etc/sensu/handlers
     - template: jinja
+    - require:
+      - pkg: sensu-server-pkg
+    - require_in:
+      - service: sensu-server
 
 /etc/sensu/conf.d/handlers.json:
   file:
@@ -23,6 +27,10 @@
     - makedirs: true
     - source: salt://monitor/etc/sensu/conf.d/handlers.json
     - template: jinja
+    - require:
+      - pkg: sensu-server-pkg
+    - require_in:
+      - service: sensu-server
 
 # The following is a list of dependencies for any of the handlers. Because
 # we're using the embedded ruby included with Sensu, we need to use cmd.run to
@@ -39,4 +47,6 @@
         - GEM_PATH: /opt/sensu/embedded/lib/ruby/gems/2.0.0:$GEM_PATH
     - require:
         - pkg: sensu-server-pkg
+    - require_in:
+        - service: sensu-server
 {% endfor %}

--- a/monitor/sensu/mutators/init.sls
+++ b/monitor/sensu/mutators/init.sls
@@ -16,6 +16,10 @@
     - recurse: true
     - source: salt://monitor/etc/sensu/mutators
     - template: jinja
+    - require:
+      - pkg: sensu-server-pkg
+    - require_in:
+      - service: sensu-server
 
 /etc/sensu/conf.d/mutators.json:
   file:
@@ -23,4 +27,8 @@
     - makedirs: true
     - source: salt://monitor/etc/sensu/conf.d/mutators.json
     - template: jinja
+    - require:
+      - pkg: sensu-server-pkg
+    - require_in:
+      - service: sensu-server
 

--- a/monitor/sensu/server/landing_page.sls
+++ b/monitor/sensu/server/landing_page.sls
@@ -14,10 +14,14 @@ apache2-landing-pkg:
     - source: salt://monitor/var/www/html
     - template: jinja
     - makedirs: true
+    - require:
+      - pkg: apache2-landing-pkg
 
 /etc/apache2/sites-enabled/000-default.conf:
   file:
-    - absent 
+    - absent
+    - require:
+      - pkg: apache2-landing-pkg
 
 /etc/apache2/sites-available:
   file:
@@ -26,23 +30,35 @@ apache2-landing-pkg:
     - template: jinja
     - clean: true
     - makedirs: true
+    - require:
+      - pkg: apache2-landing-pkg
 
 /etc/apache2/ports.conf:
   file:
     - managed
     - source: salt://monitor/etc/apache2/ports.conf
     - template: jinja
+    - require:
+      - pkg: apache2-landing-pkg
 
 /etc/apache2/sites-enabled/default.conf:
   file:
     - symlink
     - target: /etc/apache2/sites-available/default.conf
     - unless: ls /etc/apache2/sites-enabled/default.conf
+    - require:
+      - pkg: apache2-landing-pkg
 
 apache2-svc:
   service:
     - running
     - name: apache2
+    - require:
+      - file: /var/www/html
+      - file: /etc/apache2/sites-enabled/000-default.conf
+      - file: /etc/apache2/sites-available
+      - file: /etc/apache2/ports.conf
+      - file: /etc/apache2/sites-enabled/default.conf
     - watch: 
       - file: /etc/apache2/sites-available
       - file: /etc/apache2/ports.conf

--- a/monitor/sensu/server/rabbitmq.sls
+++ b/monitor/sensu/server/rabbitmq.sls
@@ -40,7 +40,7 @@ rabbitmq-server-pkg:
     - installed
     - name: rabbitmq-server
     - require:
-      - pkgrepo: rabbitmq-repo
+#      - pkgrepo: rabbitmq-repo
       - file: /etc/apt/sources.list.d/rabbitmq.list
       - cmd: rabbitmq-repo-key
 

--- a/monitor/sensu/server/rabbitmq.sls
+++ b/monitor/sensu/server/rabbitmq.sls
@@ -39,6 +39,10 @@ rabbitmq-server-pkg:
   pkg:
     - installed
     - name: rabbitmq-server
+    - require:
+      - pkgrepo: rabbitmq-repo
+      - file: /etc/apt/sources.list.d/rabbitmq.list
+      - cmd: rabbitmq-repo-key
 
 {% endif %}
 
@@ -47,42 +51,59 @@ rabbitmq-server-pkg:
     - managed
     - contents_pillar: monitor:sensu:ssl:server_cacert
     - makedirs: true
+    - require:
+      - pkg: rabbitmq-server-pkg
 
 /etc/rabbitmq/ssl/cert.pem:
   file:
     - managed
     - contents_pillar: monitor:sensu:ssl:server_cert
     - makedirs: true
+    - require:
+      - pkg: rabbitmq-server-pkg
 
 /etc/rabbitmq/ssl/key.pem:
   file:
     - managed
     - contents_pillar: monitor:sensu:ssl:server_key
     - makedirs: true
+    - require:
+      - pkg: rabbitmq-server-pkg
 
 /etc/rabbitmq/rabbitmq.config:
   file:
     - managed
     - source: salt://monitor/etc/rabbitmq/rabbitmq.config
     - makedirs: true
+    - require:
+      - pkg: rabbitmq-server-pkg
 
 create_vhost:
   cmd:
     - run
     - name: "rabbitmqctl add_vhost {{ rabbit_vhost }}"
     - unless: 'rabbitmqctl list_vhosts | grep "{{ rabbit_vhost }}"'
+    - require:
+      - file: /etc/rabbitmq/ssl/cacert.pem
+      - file: /etc/rabbitmq/ssl/cert.pem
+      - file: /etc/rabbitmq/ssl/key.pem
+      - file: /etc/rabbitmq/rabbitmq.config
 
 rabbit_user:
   cmd:
     - run
     - name: 'rabbitmqctl add_user {{ rabbit_username }} {{ rabbit_password }}'
     - unless: 'rabbitmqctl list_users | grep {{ rabbit_username }}'
+    - require:
+      - cmd: create_vhost
 
 rabbit_permissions:
   cmd:
     - run
     - name: 'rabbitmqctl set_permissions -p {{ rabbit_vhost }} {{ rabbit_username }} ".*" ".*" ".*"'
     - unless: 'rabbitmqctl list_permissions -p {{ rabbit_vhost }} | grep -v "{{ rabbit_vhost }}" | grep {{rabbit_username}}'
+    - require:
+      - cmd: rabbit_user
 
 #rabbit_web_console:
 #  cmd:
@@ -97,6 +118,8 @@ rabbitmq-server-svc:
     - running
     - name: rabbitmq-server
     - enable: true
+    - require:
+      - cmd: rabbit_permissions
     - watch:
       - file: /etc/rabbitmq/rabbitmq.config
       - file: /etc/rabbitmq/ssl/cacert.pem

--- a/monitor/sensu/server/redis.sls
+++ b/monitor/sensu/server/redis.sls
@@ -5,3 +5,5 @@ redis-server:
   service:
     - running
     - enable: true
+    - require:
+      - pkg: redis-server

--- a/monitor/sensu/uchiwa/init.sls
+++ b/monitor/sensu/uchiwa/init.sls
@@ -15,10 +15,14 @@ uchiwa-pkg:
     - user: uchiwa
     - group: sensu
     - template: jinja
+    - require:
+      - pkg: uchiwa-pkg
 
 uchiwa-svc:
   service:
     - running
     - name: uchiwa
     - enable: true
+    - require:
+      - file: /etc/sensu/uchiwa.json
 


### PR DESCRIPTION
- This allows us to have more than one sensu server per stackdio instance
- A lot of this PR is adding requisites to states - there was some issues with the ordering the states were running, so I just added requisites to everything to avoid the problem in the future.
