### PR TITLE
Fixed issue where PATH wasn't being set correctly

### DIFF
--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -36,8 +36,7 @@ gem-pkgs:
     - env:
         - PLUGINS_DIR: /etc/sensu/plugins
         - HANDLERS_DIR: /etc/sensu/handlers
-        - PATH: /opt/sensu/embedded/bin:$PATH:$PLUGINS_DIR:$HANDLERS_DIR
-        - GEM_PATH: /opt/sensu/embedded/lib/ruby/gems/2.0.0:$GEM_PATH
+        - GEM_PATH: /opt/sensu/embedded/lib/ruby/gems/2.0.0
     - require:
         - file: /etc/sensu/plugins
         - pkg: gem-pkgs


### PR DESCRIPTION
Some time in the recent past, something has changed causing '$' characters to be escaped when passed in through salt.  This was causing the PATH to have '$' included in it rather than the vars being expanded.  Because of this, ruby couldn't find gcc, and the gem install was failing.
