### PR TITLE
fs usage monitoring and alerting added

### DIFF
--- a/monitor/etc/sensu/conf.d/check_system.json
+++ b/monitor/etc/sensu/conf.d/check_system.json
@@ -25,6 +25,12 @@
       "command": "/etc/sensu/plugins/vmstat-metrics.rb --scheme sensu.:::name:::",
       "interval": 60,
       "subscribers": [ "all" ]
+    },
+    "fs_checks": {
+      "handlers": ["mailer-ses"],
+      "command": "/etc/sensu/plugins/check-disk-usages.rb -w 75 -c 80",
+      "interval": 60,
+      "subscibers": ["all"]
     }
   }
 }

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -24,6 +24,8 @@ gem-pkgs:
       - gcc
       - patch
       - zlib-devel
+      - sensu-plugins-disk-checks
+      - sys-filesystem
 
 # The following is a list of dependencies for any of the handlers. Because
 # we're using the embedded ruby included with Sensu, we need to use cmd.run to

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -24,13 +24,11 @@ gem-pkgs:
       - gcc
       - patch
       - zlib-devel
-      - sensu-plugins-disk-checks
-      - sys-filesystem
 
 # The following is a list of dependencies for any of the handlers. Because
 # we're using the embedded ruby included with Sensu, we need to use cmd.run to
 # manipulate the GEM_PATH (vs the more salty gem.installed).
-{% for gem in [ 'aws-sdk-v1', ] %}
+{% for gem in [ 'aws-sdk-v1', 'sensu-plugins-disk-checks', 'sys-filesystem', ] %}
 {{gem}}-gem:
   cmd.run:
     - name: /opt/sensu/embedded/bin/gem install {{gem}}


### PR DESCRIPTION
Not sure if explicitly installing the FS gem is needed but can't hurt to do it at install time.
75% for warn should cause alerts for some hosts and that is to plan
80% at first look around should not go off. might move it to 85 or 90 once we have confidence 
