### PR TITLE
Sensu.23

### DIFF
--- a/SPECFILE
+++ b/SPECFILE
@@ -33,6 +33,7 @@ pillar_defaults:
       webserver: nginx
       gen_ssl: null
     sensu:
+      version: 1:0.25.3
       ssl:
         server_cacert: CHANGEME
         server_cert: CHANGEME

--- a/SPECFILE
+++ b/SPECFILE
@@ -82,5 +82,6 @@ pillar_defaults:
       username: admin
       password: CHANGEME
       storage_dir: /mnt/influxdb
+      version: 0.12.2-1
     pagerduty:
       api_key: null

--- a/monitor/etc/influxdb/influxdb.conf
+++ b/monitor/etc/influxdb/influxdb.conf
@@ -22,7 +22,7 @@ reporting-disabled = true
 
 [meta]
   # Where the metadata/raft database is stored
-  dir = "/var/lib/influxdb/meta"
+  dir = "{{ pillar.monitor.influxdb.storage_dir }}/meta"
 
   retention-autocreate = true
 

--- a/monitor/etc/influxdb/influxdb.conf
+++ b/monitor/etc/influxdb/influxdb.conf
@@ -1,44 +1,150 @@
-reporting-disabled = false
+### Welcome to the InfluxDB configuration file.
+
+# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
+# The data includes raft id (random 8 bytes), os, arch, version, and metadata.
+# We don't track ip addresses of servers reporting. This is only used
+# to track the number of instances running and the versions, which
+# is very helpful for us.
+# Change this option to true to disable reporting.
+reporting-disabled = true
+
+# we'll try to get the hostname automatically, but if it the os returns something
+# that isn't resolvable by other servers in the cluster, use this option to
+# manually set the hostname
+# hostname = "localhost"
+
+###
+### [meta]
+###
+### Controls the parameters for the Raft consensus group that stores metadata
+### about the InfluxDB cluster.
+###
 
 [meta]
-  dir = "{{ pillar.monitor.influxdb.storage_dir }}/meta"
-  hostname = "localhost"
-  bind-address = ":8088"
+  # Where the metadata/raft database is stored
+  dir = "/var/lib/influxdb/meta"
+
   retention-autocreate = true
-  election-timeout = "1s"
-  heartbeat-timeout = "1s"
-  leader-lease-timeout = "500ms"
-  commit-timeout = "50ms"
-  cluster-tracing = false
+
+  # If log messages are printed for the meta service
+  logging-enabled = true
+  pprof-enabled = false
+
+  # The default duration for leases.
+  lease-duration = "1m0s"
+
+###
+### [data]
+###
+### Controls where the actual shard data for InfluxDB lives and how it is
+### flushed from the WAL. "dir" may need to be changed to a suitable place
+### for your system, but the WAL settings are an advanced configuration. The
+### defaults should work for most systems.
+###
 
 [data]
-  dir = "{{ pillar.monitor.influxdb.storage_dir }}/data"
-  engine = "bz1"
-  max-wal-size = 104857600
-  wal-flush-interval = "10m0s"
-  wal-partition-flush-delay = "2s"
-  wal-dir = "{{ pillar.monitor.influxdb.storage_dir }}/wal"
+  # Controls if this node holds time series data shards in the cluster
+  enabled = true
+
+  dir = "/var/lib/influxdb/data"
+
+  # These are the WAL settings for the storage engine >= 0.9.3
+  wal-dir = "/var/lib/influxdb/wal"
   wal-logging-enabled = true
-  wal-ready-series-size = 30720
-  wal-compaction-threshold = 0.5
-  wal-max-series-size = 1048576
-  wal-flush-cold-interval = "5s"
-  wal-partition-size-threshold = 20971520
+  data-logging-enabled = true
+
+  # Whether queries should be logged before execution. Very useful for troubleshooting, but will
+  # log any sensitive data contained within a query.
+  # query-log-enabled = true
+
+  # Settings for the TSM engine
+
+  # CacheMaxMemorySize is the maximum size a shard's cache can
+  # reach before it starts rejecting writes.
+  # cache-max-memory-size = 524288000
+
+  # CacheSnapshotMemorySize is the size at which the engine will
+  # snapshot the cache and write it to a TSM file, freeing up memory
+  # cache-snapshot-memory-size = 26214400
+
+  # CacheSnapshotWriteColdDuration is the length of time at
+  # which the engine will snapshot the cache and write it to
+  # a new TSM file if the shard hasn't received writes or deletes
+  # cache-snapshot-write-cold-duration = "1h"
+
+  # MinCompactionFileCount is the minimum number of TSM files
+  # that need to exist before a compaction cycle will run
+  # compact-min-file-count = 3
+
+  # CompactFullWriteColdDuration is the duration at which the engine
+  # will compact all TSM files in a shard if it hasn't received a
+  # write or delete
+  # compact-full-write-cold-duration = "24h"
+
+  # MaxPointsPerBlock is the maximum number of points in an encoded
+  # block in a TSM file. Larger numbers may yield better compression
+  # but could incur a performance peanalty when querying
+  # max-points-per-block = 1000
+
+###
+### [cluster]
+###
+### Controls non-Raft cluster behavior, which generally includes how data is
+### shared across shards.
+###
 
 [cluster]
-  force-remote-mapping = false
-  write-timeout = "5s"
-  shard-writer-timeout = "5s"
-  shard-mapper-timeout = "5s"
+  shard-writer-timeout = "5s" # The time within which a remote shard must respond to a write request.
+  write-timeout = "10s" # The time within which a write request must complete on the cluster.
+  max-concurrent-queries = 0 # The maximum number of concurrent queries that can run. 0 to disable.
+  query-timeout = "0s" # The time within a query must complete before being killed automatically. 0s to disable.
+  max-select-point = 0 # The maximum number of points to scan in a query. 0 to disable.
+  max-select-series = 0 # The maximum number of series to select in a query. 0 to disable.
+  max-select-buckets = 0 # The maximum number of buckets to select in an aggregate query. 0 to disable.
+
+###
+### [retention]
+###
+### Controls the enforcement of retention policies for evicting old data.
+###
 
 [retention]
   enabled = true
-  check-interval = "30m0s"
+  check-interval = "30m"
+
+###
+### [shard-precreation]
+###
+### Controls the precreation of shards, so they are available before data arrives.
+### Only shards that, after creation, will have both a start- and end-time in the
+### future, will ever be created. Shards are never precreated that would be wholly
+### or partially in the past.
 
 [shard-precreation]
   enabled = true
-  check-interval = "10m0s"
-  advance-period = "30m0s"
+  check-interval = "10m"
+  advance-period = "30m"
+
+###
+### Controls the system self-monitoring, statistics and diagnostics.
+###
+### The internal database for monitoring data is created automatically if
+### if it does not already exist. The target retention within this database
+### is called 'monitor' and is also created with a retention period of 7 days
+### and a replication factor of 1, if it does not exist. In all cases the
+### this retention policy is configured as the default for the database.
+
+[monitor]
+  store-enabled = true # Whether to record statistics internally.
+  store-database = "_internal" # The destination database for recorded statistics
+  store-interval = "10s" # The interval at which to record statistics
+
+###
+### [admin]
+###
+### Controls the availability of the built-in, web-based admin interface. If HTTPS is
+### enabled for the admin interface, HTTPS must also be enabled on the [http] service.
+###
 
 [admin]
   enabled = true
@@ -46,61 +152,146 @@ reporting-disabled = false
   https-enabled = false
   https-certificate = "/etc/ssl/influxdb.pem"
 
-[monitor]
-  store-enabled = true
-  store-database = "_internal"
-  store-interval = "10s"
+###
+### [http]
+###
+### Controls how the HTTP endpoints are configured. These are the primary
+### mechanism for getting data into and out of InfluxDB.
+###
 
 [http]
   enabled = true
   bind-address = ":8086"
-  auth-enabled = false
+  auth-enabled = true
   log-enabled = true
   write-tracing = false
   pprof-enabled = false
   https-enabled = false
   https-certificate = "/etc/ssl/influxdb.pem"
+  max-row-limit = 10000
+
+###
+### [[graphite]]
+###
+### Controls one or many listeners for Graphite data.
+###
+
+[[graphite]]
+  enabled = false
+  # database = "graphite"
+  # bind-address = ":2003"
+  # protocol = "tcp"
+  # consistency-level = "one"
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 5000 # will flush if this many points get buffered
+  # batch-pending = 10 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+  # udp-read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+
+  ### This string joins multiple matching 'measurement' values providing more control over the final measurement name.
+  # separator = "."
+
+  ### Default tags that will be added to all metrics.  These can be overridden at the template level
+  ### or by tags extracted from metric
+  # tags = ["region=us-east", "zone=1c"]
+
+  ### Each template line requires a template pattern.  It can have an optional
+  ### filter before the template and separated by spaces.  It can also have optional extra
+  ### tags following the template.  Multiple tags should be separated by commas and no spaces
+  ### similar to the line protocol format.  There can be only one default template.
+  # templates = [
+  #   "*.app env.service.resource.measurement",
+  #   # Default template
+  #   "server.*",
+  # ]
+
+###
+### [collectd]
+###
+### Controls the listener for collectd data.
+###
 
 [collectd]
   enabled = false
-  bind-address = ":25826"
-  database = "collectd"
-  retention-policy = ""
-  batch-size = 1000
-  batch-pending = 5
-  batch-timeout = "10s"
-  typesdb = "/usr/share/collectd/types.db"
+  # bind-address = ""
+  # database = ""
+  # typesdb = ""
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+  # read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+
+###
+### [opentsdb]
+###
+### Controls the listener for OpenTSDB data.
+###
 
 [opentsdb]
   enabled = false
-  bind-address = ":4242"
-  database = "opentsdb"
-  retention-policy = ""
-  consistency-level = "one"
-  tls-enabled = false
-  certificate = "/etc/ssl/influxdb.pem"
-  batch-size = 1000
-  batch-pending = 5
-  batch-timeout = "1s"
+  # bind-address = ":4242"
+  # database = "opentsdb"
+  # retention-policy = ""
+  # consistency-level = "one"
+  # tls-enabled = false
+  # certificate= ""
+  # log-point-errors = true # Log an error for every malformed point.
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Only points
+  # metrics received over the telnet protocol undergo batching.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+
+###
+### [[udp]]
+###
+### Controls the listeners for InfluxDB line protocol data via UDP.
+###
+
+[[udp]]
+  enabled = true
+   bind-address = ":8090"
+   database = "sensu"
+   batch-size = 1000 # will flush if this many points get buffered
+   batch-pending = 5 # number of batches that may be pending in memory
+   batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+   read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+
+  # bind-address = ""
+  # database = "udp"
+  # retention-policy = ""
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+  # read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+
+  # set the expected UDP payload size; lower values tend to yield better performance, default is max UDP size 65536
+  # udp-payload-size = 65536
+
+###
+### [continuous_queries]
+###
+### Controls how continuous queries are run within InfluxDB.
+###
 
 [continuous_queries]
   log-enabled = true
   enabled = true
-  recompute-previous-n = 2
-  recompute-no-older-than = "10m0s"
-  compute-runs-per-interval = 10
-  compute-no-more-than = "2m0s"
-
-[hinted-handoff]
-  enabled = true
-  dir = "{{ pillar.monitor.influxdb.storage_dir }}/hh"
-  max-size = 1073741824
-  max-age = "168h0m0s"
-  retry-rate-limit = 0
-  retry-interval = "1s"
-
-[[graphite]]
-  enabled = true
-  bind-address = ":2003"
-  protocol = "tcp"
-  # consistency-level = "one"
+  # run-interval = "1s" # interval for how often continuous queries will be checked if they need to run

--- a/monitor/etc/influxdb/influxdb.conf
+++ b/monitor/etc/influxdb/influxdb.conf
@@ -177,8 +177,8 @@ reporting-disabled = true
 ###
 
 [[graphite]]
-  enabled = false
-  # database = "graphite"
+  enabled = true
+  database = "graphite"
   # bind-address = ":2003"
   # protocol = "tcp"
   # consistency-level = "one"

--- a/monitor/etc/nginx/sites-enabled/monitor.conf
+++ b/monitor/etc/nginx/sites-enabled/monitor.conf
@@ -13,6 +13,11 @@ server {
 
     access_log  /var/log/nginx/access.log;
 
+    location /system/status/ {
+        stub_status on;
+        access_log off;
+    }
+
     location /grafana {
         proxy_pass  http://localhost:3001;
         rewrite  ^/grafana/(.*)  /$1 break;

--- a/monitor/etc/sensu/conf.d/check_system.json
+++ b/monitor/etc/sensu/conf.d/check_system.json
@@ -7,27 +7,27 @@
   "checks": {
     "load_check": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-load.rb",
+      "command": "/opt/sensu/embedded/bin/check-load.rb",
       "interval": 60,
       "subscribers": [ "all" ]
     },
     "mem_check": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-mem.sh",
+      "command": "/opt/sensu/embedded/bin/check-memory.rb",
       "interval": 60,
       "subscribers": [ "all" ]
     },
     "disk_metrics": {
       "handlers": ["graphite-tcp"],
       "type": "metric",
-      "command": "/etc/sensu/plugins/disk-usage-metrics.rb --scheme sensu.:::name:::",
+      "command": "/opt/sensu/embedded/bin/metrics-disk-usage.rb --scheme sensu.:::name:::",
       "interval": 60,
       "subscribers": [ "all" ]
     },
     "vmstat_metrics": {
       "handlers": ["graphite-tcp" ],
       "type": "metric",
-      "command": "/etc/sensu/plugins/vmstat-metrics.rb --scheme sensu.:::name:::",
+      "command": "/opt/sensu/embedded/bin/metrics-vmstat.rb  --scheme sensu.:::name:::",
       "interval": 60,
       "subscribers": [ "all" ]
     },

--- a/monitor/etc/sensu/conf.d/check_system.json
+++ b/monitor/etc/sensu/conf.d/check_system.json
@@ -13,7 +13,7 @@
     },
     "mem_check": {
       "handlers": ["default"],
-      "command": "/opt/sensu/embedded/bin/check-memory.rb",
+      "command": "/opt/sensu/embedded/bin/check-memory.rb -w 1000 -c 500",
       "interval": 60,
       "subscribers": [ "all" ]
     },

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -10,15 +10,15 @@
     },
     "mailer-ses": {
       "type": "pipe",
-      "command": "/etc/sensu/handlers/mailer-ses.rb"
+      "command": "/opt/sensu/embedded/bin/handler-ses.rb"
     },
     "sns": {
       "type": "pipe",
-      "command": "/etc/sensu/handlers/sns.rb"
+      "command": "/opt/sensu/embedded/bin/handler-sns.rb"
     },
     "remediator": {
       "type": "pipe",
-      "command": "/etc/sensu/handlers/remediator.rb"
+      "command": "/opt/sensu/embedded/bin/handler-sensu.rb"
     },
     "file-handler": {
       "type": "pipe",
@@ -30,7 +30,7 @@
     },
     "pagerduty": {
       "type": "pipe",
-      "command": "/etc/sensu/handlers/pagerduty.rb"
+      "command": "/opt/sensu/embedded/bin/handler-pagerduty.rb"
   }
 
   },

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -1,7 +1,7 @@
 {
   "influxdb": {
-      "username": "admin",
-      "password": "influxdb_password1",
+      "username": "{{ pillar.monitor.influxdb.user }} ",
+      "password": "{{ pillar.monitor.influxdb.password }}",
       "database": "sensu",
       "host": "localhost",
       "port": 8086

--- a/monitor/etc/sensu/conf.d/handlers.json
+++ b/monitor/etc/sensu/conf.d/handlers.json
@@ -1,4 +1,11 @@
 {
+  "influxdb": {
+      "username": "admin",
+      "password": "influxdb_password1",
+      "database": "sensu",
+      "host": "localhost",
+      "port": 8086
+  },
   "handlers": {
     "graphite-tcp": {
       "type": "tcp",
@@ -7,6 +14,10 @@
           "host": "localhost",
           "port": 2003
       }
+    },
+    "influx-tcp": {
+      "type": "pipe",
+      "command": "/opt/sensu/embedded/bin/metrics-influxdb.rb"
     },
     "mailer-ses": {
       "type": "pipe",

--- a/monitor/etc/sensu/uchiwa.json
+++ b/monitor/etc/sensu/uchiwa.json
@@ -16,6 +16,6 @@
     "pass": "{{ pillar.monitor.sensu.uchiwa.password }}",
     "port": 3000,
     "stats": 10,
-    "refresh": 10000
+    "refresh": 10
   }
 }

--- a/monitor/influxdb/init.sls
+++ b/monitor/influxdb/init.sls
@@ -38,7 +38,7 @@ influxdb:
     - require:
       - pkg: influxdb_pkg
 
-infulx_user:
+influx_user:
   cmd:
     - run
     - name: /usr/bin/influx -execute "CREATE USER {{username}} WITH PASSWORD '{{password}}' WITH ALL PRIVILEGES"

--- a/monitor/influxdb/init.sls
+++ b/monitor/influxdb/init.sls
@@ -1,14 +1,21 @@
 {%- set username = salt['pillar.get']('monitor:influxdb:username') -%}
 {%- set password = salt['pillar.get']('monitor:influxdb:password') -%}
+{%- set influx_ver = salt['pillar.get']('monitor:influxdb:version') -%}
 #
 # Install and configure influxDB
 #
 
-
+{% if grains["os_family"] == "Debian" %}
 influxdb_pkg:
   pkg.installed:
     - sources:
-      - influxdb: http://influxdb.s3.amazonaws.com/influxdb_0.9.4.2_amd64.deb
+      - influxdb: http://influxdb.s3.amazonaws.com/influxdb_{{influx_ver}}_amd64.deb
+{% elif grains["os_family"] == "RedHat" %}
+influxdb_pkg:
+  pkg.installed:
+    - sources:
+      - influxdb: http://influxdb.s3.amazonaws.com/influxdb_{{influx_ver}}.x86_64.rpm
+{% endif %}
 
 /etc/opt/influxdb/influxdb.conf:
   file:

--- a/monitor/influxdb/init.sls
+++ b/monitor/influxdb/init.sls
@@ -17,7 +17,7 @@ influxdb_pkg:
       - influxdb: http://influxdb.s3.amazonaws.com/influxdb_{{influx_ver}}.x86_64.rpm
 {% endif %}
 
-/etc/opt/influxdb/influxdb.conf:
+/etc/influxdb/influxdb.conf:
   file:
     - managed
     - source: salt://monitor/etc/influxdb/influxdb.conf

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -1,4 +1,4 @@
-
+{%- set sensu_version = pillar.monitor.sensu.version -%}
 #
 # This installs the Sensu client and all of it's dependencies.
 #
@@ -14,6 +14,7 @@ sensu-client-pkg:
   pkg:
     - installed
     - name: sensu
+    - version: {{ sensu_version }}-1
     - require:
       - pkgrepo: sensu-repo
 

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -15,6 +15,7 @@ sensu-client-pkg:
     - installed
     - name: sensu
     - version: {{ sensu_version }}-1
+    - allow_updates: true
     - require:
       - pkgrepo: sensu-repo
 

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -16,6 +16,7 @@ sensu-client-pkg:
     - name: sensu
     - version: {{ sensu_version }}-1
     - allow_updates: true
+    - normalize: false
     - require:
       - pkgrepo: sensu-repo
 

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -15,9 +15,6 @@ sensu-client-pkg:
     - installed
     - name: sensu
     - version: {{ sensu_version }}-1
-    - allow_updates: true
-    - normalize: false
-    - pkg_verify: true
     - require:
       - pkgrepo: sensu-repo
 

--- a/monitor/sensu/client/init.sls
+++ b/monitor/sensu/client/init.sls
@@ -17,6 +17,7 @@ sensu-client-pkg:
     - version: {{ sensu_version }}-1
     - allow_updates: true
     - normalize: false
+    - pkg_verify: true
     - require:
       - pkgrepo: sensu-repo
 

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -16,11 +16,12 @@ gem-pkgs:
     - pkgs:
       - gcc
       - patch
-      - libxml2
 {% if grains["os_family"] == "RedHat" %}
       - zlib-devel
+      - libxml2-devel
 {% elif grains["os_family"] == "Debian" %}
       - zlib1g-dev
+      - libxml2-dev
 {% endif %}
 
 

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -19,9 +19,11 @@ gem-pkgs:
 {% if grains["os_family"] == "RedHat" %}
       - zlib-devel
       - libxml2-devel
+      - gcc-c++
 {% elif grains["os_family"] == "Debian" %}
       - zlib1g-dev
       - libxml2-dev
+      - g++
 {% endif %}
 
 

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -26,7 +26,7 @@ gem-pkgs:
 {% for plugin in plugin_list %}
 {{plugin}}-install:
   cmd.run:
-    - name: usr/bin/sensu-install -p {{plugin}}
+    - name: /usr/bin/sensu-install -p {{plugin}}
     - require:
         - pkg: gem-pkgs
         - pkg: sensu-client-pkg

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -6,7 +6,7 @@
 # or write your own based on http://sensuapp.org/docs/latest/checks
 #
 
-{% set plugin_list = [ 'disk-checks', 'aws', 'filesystem-checks', 
+{% set plugin_list = [ 'disk-checks', 'aws', 'filesystem-checks', 'load-checks', 
   'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
   'nginx', 'vmstats' ] %}
 

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -16,6 +16,7 @@ gem-pkgs:
     - pkgs:
       - gcc
       - patch
+      - libxml2
 {% if grains["os_family"] == "RedHat" %}
       - zlib-devel
 {% elif grains["os_family"] == "Debian" %}

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -8,7 +8,7 @@
 
 {% set plugin_list = [ 'disk-checks', 'aws', 'filesystem-checks', 'load-checks', 
   'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
-  'nginx', 'vmstats', 'supervisor' ] %}
+  'nginx', 'vmstats', 'supervisor', 'memory-checks', 'sensu' ] %}
 
 gem-pkgs:
   pkg:

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -2,13 +2,13 @@
 #
 # This state should be run on all hosts.
 #
-# You can get more plugins from https://github.com/sensu/sensu-community-plugins/tree/master/plugins 
+# You can get more plugins from https://github.com/sensu-plugins
 # or write your own based on http://sensuapp.org/docs/latest/checks
 #
 
 {% set plugin_list = [ 'disk-checks', 'aws', 'filesystem-checks', 'load-checks', 
   'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
-  'nginx', 'vmstats' ] %}
+  'nginx', 'vmstats', 'supervisor' ] %}
 
 gem-pkgs:
   pkg:

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -6,20 +6,9 @@
 # or write your own based on http://sensuapp.org/docs/latest/checks
 #
 
-{% set gems = ['aws-sdk-v1', 'sensu-plugins-disk-checks', 'sys-filesystem', 'sensu-plugins-influxdb', 'redphone', 'sensu-plugins-redis'] %}
-
-/etc/sensu/plugins:
-  file:
-    - recurse
-    - makedirs: true
-    - clean: true
-    - file_mode: 755
-    - dir_mode: 755
-    - recurse: true
-    - source: salt://monitor/etc/sensu/plugins
-    - template: jinja
-    - require:
-      - pkg: sensu-client-pkg
+{% set plugin_list = ['process-checks', 'disk-checks', 'plugins-aws', 'filesystem-checks', 
+  'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
+  'nginx', 'vmstats'    ] %}
 
 gem-pkgs:
   pkg:
@@ -33,20 +22,12 @@ gem-pkgs:
       - zlib1g-dev
 {% endif %}
 
-# The following is a list of dependencies for any of the handlers. Because
-# we're using the embedded ruby included with Sensu, we need to use cmd.run to
-# manipulate the GEM_PATH (vs the more salty gem.installed).
-{% for gem in gems %}
-{{gem}}-gem:
+
+{% for plugin in plugin_list %}
+{{plugin}}-install:
   cmd.run:
-    - name: /opt/sensu/embedded/bin/gem install {{gem}}
-    - unless: /opt/sensu/embedded/bin/gem list --local | grep {{gem}}
-    - env:
-        - PLUGINS_DIR: /etc/sensu/plugins
-        - HANDLERS_DIR: /etc/sensu/handlers
-        - GEM_PATH: /opt/sensu/embedded/lib/ruby/gems/2.0.0
+    - name: usr/bin/sensu-install -p {{plugin}}
     - require:
-        - file: /etc/sensu/plugins
         - pkg: gem-pkgs
         - pkg: sensu-client-pkg
         - file: /etc/default/sensu

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -6,7 +6,7 @@
 # or write your own based on http://sensuapp.org/docs/latest/checks
 #
 
-{% set plugin_list = [ 'disk-checks', 'plugins-aws', 'filesystem-checks', 
+{% set plugin_list = [ 'disk-checks', 'aws', 'filesystem-checks', 
   'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
   'nginx', 'vmstats' ] %}
 

--- a/monitor/sensu/plugins/init.sls
+++ b/monitor/sensu/plugins/init.sls
@@ -6,9 +6,9 @@
 # or write your own based on http://sensuapp.org/docs/latest/checks
 #
 
-{% set plugin_list = ['process-checks', 'disk-checks', 'plugins-aws', 'filesystem-checks', 
+{% set plugin_list = [ 'disk-checks', 'plugins-aws', 'filesystem-checks', 
   'redis', 'influxdb', 'slack', 'pagerduty', 'graphite', 'http', 'logs', 'process-checks', 
-  'nginx', 'vmstats'    ] %}
+  'nginx', 'vmstats' ] %}
 
 gem-pkgs:
   pkg:

--- a/monitor/sensu/repo.sls
+++ b/monitor/sensu/repo.sls
@@ -7,12 +7,12 @@ sensu-repo:
   pkgrepo:
     - managed
 {% if grains["os_family"] == "Debian" %}
-    - key_url: http://repos.sensuapp.org/apt/pubkey.gpg
-    - name: deb http://repos.sensuapp.org/apt sensu main
+    - key_url: http://repositories.sensuapp.org/apt/pubkey.gpg 
+    - name: deb http://repositories.sensuapp.org/apt sensu main
     - refresh_db: true
 {% elif grains["os_family"] == "RedHat" %}
     - humanname: sensu-main
-    - baseurl: http://repos.sensuapp.org/yum/el/$releasever/$basearch/
+    - baseurl: http://repositories.sensuapp.org/yum/$basearch/
     - gpgcheck: 0
 {% endif %}
 

--- a/monitor/sensu/repo.sls
+++ b/monitor/sensu/repo.sls
@@ -12,7 +12,7 @@ sensu-repo:
     - refresh_db: true
 {% elif grains["os_family"] == "RedHat" %}
     - humanname: sensu
-    - name: sensu
+    - name: sensu-repo
     - baseurl: http://repositories.sensuapp.org/yum/$basearch/
     - gpgcheck: 0
     - enabled: 1

--- a/monitor/sensu/repo.sls
+++ b/monitor/sensu/repo.sls
@@ -11,8 +11,10 @@ sensu-repo:
     - name: deb http://repositories.sensuapp.org/apt sensu main
     - refresh_db: true
 {% elif grains["os_family"] == "RedHat" %}
-    - humanname: sensu-main
+    - humanname: sensu
+    - name: sensu
     - baseurl: http://repositories.sensuapp.org/yum/$basearch/
     - gpgcheck: 0
+    - enabled: 1
 {% endif %}
 

--- a/monitor/usr/share/sensu/restart_sensu.sh
+++ b/monitor/usr/share/sensu/restart_sensu.sh
@@ -17,6 +17,3 @@ service sensu-api restart
 
 echo "## Restart client"
 service sensu-client restart
-
-echo "## Restart uchiwa"
-service uchiwa restart

--- a/monitor/usr/share/sensu/restart_sensu.sh
+++ b/monitor/usr/share/sensu/restart_sensu.sh
@@ -18,3 +18,5 @@ service sensu-api restart
 echo "## Restart client"
 service sensu-client restart
 
+echo "## Restart uchiwa"
+service uchiwa restart


### PR DESCRIPTION
Upgrades to Sensu 2.3 changes plugins over to the newer plugin system and updates paths and flags as needed.
Deals better with InfluxDB versions
Sets Sensu to send metrics directly to influx rather than the graphite endpoint
